### PR TITLE
Modification of watching logic.

### DIFF
--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -3,7 +3,6 @@
  * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
  * SPDX-License-Identifier: Apache-2.0
  */
-library;
 
 import 'dart:async';
 

--- a/example/bin/main_dev.dart
+++ b/example/bin/main_dev.dart
@@ -3,7 +3,6 @@
  * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
  * SPDX-License-Identifier: Apache-2.0
  */
-library;
 
 import 'dart:io' as io;
 import 'dart:isolate';

--- a/example/dummylib_v1/lib/dummylib.dart
+++ b/example/dummylib_v1/lib/dummylib.dart
@@ -3,7 +3,6 @@
  * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
  * SPDX-License-Identifier: Apache-2.0
  */
-library;
 
 String getVersion() {
   return 'v1';

--- a/example/dummylib_v2/lib/dummylib.dart
+++ b/example/dummylib_v2/lib/dummylib.dart
@@ -3,7 +3,6 @@
  * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
  * SPDX-License-Identifier: Apache-2.0
  */
-library;
 
 String getVersion() {
   return 'v2';

--- a/example/lib/src/utils.dart
+++ b/example/lib/src/utils.dart
@@ -3,7 +3,6 @@
  * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
  * SPDX-License-Identifier: Apache-2.0
  */
-library;
 
 import 'package:dummylib/dummylib.dart' as dummylib;
 


### PR DESCRIPTION
*Issue #20*

*Changes the logic of applying `onBeforeReload` handler to a batch of events.*
Due to debouncing the function `_reloadCode` can receive a batch of events. When `onBeforeReload` discards some of them, all the batch is discarded and hot-reloading is skipped. The PR changes this logic: hot-reloading is skipped only if all of the events are discarded.

*Supports `excludedPaths`.*
When `watchDependencies` is `true`, the HotReloader starts watching all dependencies including the entire project. To prevent watching some of relative dependencies or entire project, this PR proposes the `excludedPaths` argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
