### PR TITLE
feat: support monorepo with pub workspace.

### DIFF
--- a/lib/hotreloader.dart
+++ b/lib/hotreloader.dart
@@ -84,19 +84,34 @@ class HotReloader {
    * and automatically triggers hot reload when Dart files are modified.
    *
    * Set [automaticReload] to `false` to require manual reload via [reloadCode].
+   *
    * The [debounceInterval] specifies the minimum time between reloads; changes within this window are batched together.
+   *
    * When [watchDependencies] is `true`, changes to package dependencies also trigger reload (includes project root).
-   * [excludedPaths] removes paths from the calculated watch list before watchers are created. Common uses:
-   * - Exclude default directories like `test` if not needed
-   * - Exclude `./` to avoid watching the entire project root when [watchDependencies] is true
-   * - Exclude sibling packages like `../other-package` from triggering reloads
-   * Note: Only works on top-level paths; cannot exclude subdirectories of watched directories.
+   *
+   * [excludedPaths] removes paths from the calculated watch list before
+   * watchers are created.
+   * [excludedPaths] are always relative to the project's root directory. If the
+   * project is a pub workspace, the `bin` folder of the package will be located
+   * in the `packages/<package>` folder. That means it should be specified like
+   * `packages/<package>/bin` in [excludedPaths], where `<package>` is the name
+   * of the package where the `HotReloader` is created. If the project consists
+   * of a single package, the `bin` directory lies in the project's root folder
+   * and should be specified like `bin` in [excludedPaths].
+   * Note: Only works on top-level paths; cannot exclude subdirectories of
+   * watched directories.
+   * Common uses:
+   * - Exclude default directories like `test` if not needed.
+   * - Exclude `./` to avoid watching the entire project root when [watchDependencies] is true.
+   * - Exclude sibling packages like `../other-package` from triggering reloads.
+   *
    * The [onBeforeReload] callback can veto reloads by returning `false`.
+   *
    * The [onAfterReload] callback receives reload results for custom handling.
    */
   static Future<HotReloader> create({
     final bool automaticReload = true,
-    final Duration debounceInterval = const Duration(seconds: 1), //
+    final Duration debounceInterval = const Duration(seconds: 1),
     final bool watchDependencies = true,
     final Set<String>? excludedPaths,
     final bool Function(BeforeReloadContext ctx)? onBeforeReload,
@@ -153,29 +168,72 @@ For hot code reloading to function properly, Dart needs to be run from the root 
     }
 
     var watchList = ['bin', 'lib', 'test'];
+    var context = p.context;
+
+    final packagesFilePath = (await pub.packagesFile).path;
+    final packagesDirPath = p.dirname(packagesFilePath);
+    final projectPath = p.dirname(packagesDirPath);
+    if (p.isAbsolute(projectPath) && context.current != projectPath) {
+      // The package is a part of the pub workspace. Change the context to the
+      // workspace root and correct relative paths in the watchList.
+      context = p.Context(current: projectPath);
+      watchList = watchList
+        .map(p.absolute)
+        .map(context.relative)
+        .toList();
+    }
 
     if (_watchDependencies) {
+      final pubCachePath = pub.pubCacheDir.path;
+      log.fine('pubCachePath: [$pubCachePath]');
+
+      bool isNotPubCached(final String path)
+      {
+        if (path == pubCachePath || p.isWithin(pubCachePath, path)) {
+          log.fine('Skipped watching cached package at [$path]');
+          return false;
+        }
+        return true;
+      }
+
       // add .packages file to watch list
-      watchList.add((await pub.packagesFile).path);
+      watchList.add(packagesFilePath);
       // add source folders of all dependencies to watch list
       final pkgConfigURL = await isolates.Isolate.packageConfig;
       if (pkgConfigURL != null) {
         log.config('pkgConfigURL: $pkgConfigURL');
         if (pkgConfigURL.path.endsWith('.json')) {
-          convert.json
-              .decode(await new io.File(pkgConfigURL.toFilePath()).readAsString())['packages']
-              .map((dynamic v) => v['rootUri'].toString())
+          final config = convert.json
+            .decode(await new io.File(pkgConfigURL.toFilePath()).readAsString());
+          final packages = config is Map<String, dynamic>
+            ? config['packages']
+            : null;
+          if (packages is List) {
+            packages
+              .whereType<Map<String, dynamic>>()
+              .map((v) => v['rootUri'].toString())
 
               // '../' means relative to <project>/.dart_tool
               // since we are already at <project> level we change '../' to './'
-              .map((dynamic rootUri) => rootUri.toString().startsWith('../') ? rootUri.substring(1) : rootUri)
-              .map((dynamic rootUri) => Uri.parse(rootUri.toString()).toFilePath())
+              .map((rootUri) => rootUri.startsWith('../')
+                ? rootUri.substring(1)
+                : rootUri
+              )
+
+              .map((rootUri) => Uri.parse(rootUri).toFilePath())
+              .where(isNotPubCached)
               .forEach(watchList.add);
+          } else {
+            log.config(
+              'Failed to watch dependencies: bad package config format.'
+            );
+          }
         } else {
           await pkgConfigURL
               .readLineByLine()
               .where((l) => !l.startsWith('#') && l.contains(':'))
               .map((l) => Uri.parse(strings.substringAfter(l, ':')).toFilePath())
+              .where(isNotPubCached)
               .forEach(watchList.add);
         }
       }
@@ -186,21 +244,17 @@ For hot code reloading to function properly, Dart needs to be run from the root 
       watchList = watchList.where((e) => !excludedPaths.contains(e)).toList();
     }
 
-    watchList = watchList.map(p.absolute).map(p.normalize).toSet().toList();
+    watchList = watchList
+      .map(context.absolute)
+      .map(context.normalize)
+      .toSet().toList();
     watchList.sort();
-
-    final pubCacheDir = pub.pubCacheDir;
-    log.fine('pubCacheDir: [${pubCacheDir.path}]');
 
     final isDockerized = await docker.isRunningInDockerContainer;
     log.fine('isDockerized: [$isDockerized]');
 
     final watchers = <Watcher>[];
     for (final path in watchList) {
-      if (path == pubCacheDir.path || p.isWithin(pubCacheDir.path, path)) {
-        log.fine('Skipped watching cached package at [$path]');
-        continue;
-      }
       if (watchers.where((w) => path == w.path || p.isWithin(w.path, path)).isNotEmpty) {
         log.fine('Skipped watching [$path] since parent path is already being watched');
         continue;
@@ -342,7 +396,7 @@ For hot code reloading to function properly, Dart needs to be run from the root 
    *
    * @param force: indicates that code from all source files should be reloaded regardless of their modification time.
    */
-  Future<HotReloadResult> reloadCode({final bool force = false}) async {
+  Future<HotReloadResult> reloadCode({final bool force = false}) {
     return _reloadCode(null, force);
   }
 


### PR DESCRIPTION
Hello again! :)

I continue using your awesome package and have faced the issue in a monorepo with [pub workspace](https://dart.dev/tools/pub/workspaces).

*Description of changes:*

When watching dependencies of the package, the hotreloader inspects `.dart_tool/package_config.json` and retrieves the path of each package in the project. This path is relative to the workspace directory but not the directory of the current package. When trying to build the absolute path of such package using p.absolute (based on the context with current package's path) we receive something like `/home/user/projects/workspace/packages/watched/packages/another` instead of having `/home/user/projects/workspace/packages/another`.

So we need check whether the package is in a workspace, and when it is:
1. Change the current context to the workspace path.
2. Correct initial `watchList` [ bin, lib, test ] -> [ packages/watched/bin, packages/watched/lib, packages/watched/test ].
3. Use the workspace context when making relative path absolute, instead of the current package's context.

Also, I'd suggest not saving pub-cached paths to the list for later discarding them. Instead, we can discard them earlier while scanning dependencies.

Thank you!