### PR TITLE
feat: Allow to modify standard package paths to watch. (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,20 @@
 1. [Requirements](#requirements)
 1. [How to use](#how-to-use)
 1. [Logging](#logging)
+1. [Pub workspaces](#pub-workspaces)
+1. [Custom watch paths](#custom-watch-paths)
 1. [Alternatives](#alternatives)
 1. [Changelog / Version History](#changelog)
 1. [License](#license)
 
 
-## <a name="what-is-it"></a>What is it?
+## <a id="what-is-it"></a>What is it?
 
 This [Dart](https://dart.dev) library provides a code reloading service that monitors the source files of a Dart project on the local file system for changes
 and automatically applies them using the Dart VM's [hot reload](https://github.com/dart-lang/sdk/wiki/Hot-reload) capabilities to the running Dart process.
 
 
-## <a name="requirements"></a>Requirements
+## <a id="requirements"></a>Requirements
 
 hotreloader 4.x requires [Dart SDK](https://dart.dev/resources/language/evolution#dart-3-0) **3.0.0** or higher.
 
@@ -29,7 +31,7 @@ hotreloader 3.x requires [Dart SDK](https://dart.dev/resources/language/evolutio
 hotreloader 1.x-2.x requires [Dart SDK](https://dart.dev/resources/language/evolution#dart-2-6) **2.6.0** or higher.
 
 
-## <a name="how-to-use"></a>How to use
+## <a id="how-to-use"></a>How to use
 
 1. Add hotreloader to your dev dependencies using this command
 
@@ -96,7 +98,7 @@ Future<void> main(List<String> args) async {
 ```
 
 
-## <a name="logging"></a>Logging
+## <a id="logging"></a>Logging
 
 This library uses the [logging](https://pub.dev/packages/logging) package for logging.
 
@@ -129,7 +131,32 @@ Future<void> main() async {
 ```
 
 
-## <a name="alternatives"></a>Alternatives
+## <a id="pub-workspaces"></a>Pub workspaces (monorepo)
+
+`hotreloader` automatically detects and supports [Pub Workspaces](https://dart.dev/tools/pub/workspaces). If your package is inside a monorepo, the correct package directory and project root are resolved automatically. No additional configuration is required.
+
+In a pub workspace, `packagePathsToWatch` are relative to the **package root**, meaning you specify just `bin`, `lib` - not `packages/my_package/bin`. Meanwhile, `projectPathsToExclude` are relative to the **project root** (the workspace root), so you specify paths like `packages/my_package/test` or `packages/another_package` - typically used to exclude dependent packages within the monorepo from triggering reloads. In a single-package project (non-workspace), both roots are the same directory, so both parameters accept paths relative to that single directory (e.g., just `test` for both).
+
+
+## <a id="custom-watch-paths"></a>Custom watch paths
+
+By default, `hotreloader` watches `bin/`, `lib/`, and `test/` inside your package, following [package layout conventions](https://dart.dev/tools/pub/package-layout). If your project uses a non-standard layout, you can override this behavior using the `packagePathsToWatch` parameter:
+
+```dart
+final reloader = await HotReloader.create(
+  packagePathsToWatch: {'routes', 'public'},
+);
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `packagePathsToWatch` | Set of paths **relative to the package root** to watch for changes. Default: `{'bin', 'lib', 'test'}` |
+| `projectPathsToExclude` | Set of **top-level paths** relative to the project root to exclude from watching. Cannot exclude subdirectories of watched directories. |
+
+**Note:** If you specify custom `packagePathsToWatch`, the default `bin/`, `lib/`, and `test/` directories are **not** watched unless explicitly included.
+
+
+## <a id="alternatives"></a>Alternatives
 
 - https://pub.dev/packages/angel_hot (last update 05/2019)
 - https://pub.dev/packages/jaguar_hotreload (last update 02/2019)
@@ -137,12 +164,12 @@ Future<void> main() async {
 - https://pub.dev/packages/reloader (last update 01/2019)
 
 
-## <a name="changelog"></a>Changelog / Version History
+## <a id="changelog"></a>Changelog / Version History
 
 This project maintains a [changelog](CHANGELOG.md) and adheres to [Semantic Versioning](https://semver.org) and [Keep a CHANGELOG](https://keepachangelog.com)
 
 
-## <a name="license"></a>License
+## <a id="license"></a>License
 
 All files are released under the [Apache License 2.0](LICENSE.txt).
 

--- a/lib/hotreloader.dart
+++ b/lib/hotreloader.dart
@@ -83,23 +83,27 @@ class HotReloader {
    *
    * The [debounceInterval] specifies the minimum time between reloads; changes within this window are batched together.
    *
-   * When [watchDependencies] is `true`, changes to package dependencies also trigger reload (includes project root).
+   * When [watchDependencies] is `true`, changes to package dependencies also trigger reload.
    *
-   * [excludedPaths] removes paths from the calculated watch list before
-   * watchers are created.
-   * [excludedPaths] are always relative to the project's root directory. If the
-   * project is a pub workspace, the `bin` folder of the package will be located
-   * in the `packages/<package>` folder. That means it should be specified like
-   * `packages/<package>/bin` in [excludedPaths], where `<package>` is the name
-   * of the package where the `HotReloader` is created. If the project consists
-   * of a single package, the `bin` directory lies in the project's root folder
-   * and should be specified like `bin` in [excludedPaths].
-   * Note: Only works on top-level paths; cannot exclude subdirectories of
+   * [packagePathsToWatch] specifies which subdirectories inside the package
+   * should be watched, relative to the **package** root. By default it contains
+   * `bin`, `lib`, and `test`.
+   *
+   * [projectPathsToExclude] removes paths from the calculated watch list before
+   * watchers are created, relative to the **project** root.
+   * **Note:** Only works on top-level paths; cannot exclude subdirectories of
    * watched directories.
    * Common uses:
    * - Exclude default directories like `test` if not needed.
-   * - Exclude `./` to avoid watching the entire project root when [watchDependencies] is true.
-   * - Exclude sibling packages like `../other-package` from triggering reloads.
+   * - Exclude specific local dependencies from triggering reloads.
+   *
+   * If the project is a pub workspace, the `test` folder of the package will be
+   * located in the `packages/<package>` folder. That means it should be
+   * specified like `packages/<package>/test` in [projectPathsToExclude], where
+   * `<package>` is the name of the package where the `HotReloader` is created.
+   * If the project consists of a single package, the `test` directory lies in
+   * the project's root folder and should be specified like `test` in
+   * [projectPathsToExclude].
    *
    * The [onBeforeReload] callback can veto reloads by returning `false`.
    *
@@ -109,7 +113,8 @@ class HotReloader {
     final bool automaticReload = true,
     final Duration debounceInterval = const Duration(seconds: 1),
     final bool watchDependencies = true,
-    final Set<String>? excludedPaths,
+    final Set<String> packagePathsToWatch = const { 'bin', 'lib', 'test' },
+    final Set<String>? projectPathsToExclude,
     final bool Function(BeforeReloadContext ctx)? onBeforeReload,
     final void Function(AfterReloadContext ctx)? onAfterReload,
   }) async {
@@ -121,7 +126,8 @@ For hot code reloading to function properly, Dart needs to be run from the root 
 
     final instance = new HotReloader._(
       watchDependencies,
-      excludedPaths,
+      packagePathsToWatch,
+      projectPathsToExclude,
       debounceInterval,
       await vm_utils.createVmService(),
       onBeforeReload,
@@ -134,14 +140,16 @@ For hot code reloading to function properly, Dart needs to be run from the root 
     return instance;
   }
 
+  bool _isStopping = false;
+  Future<void> _pendingAutomaticReload = Future<void>.value();
+
   final bool Function(BeforeReloadContext ctx)? _onBeforeReload;
   final void Function(AfterReloadContext ctx)? _onAfterReload;
 
   final Duration _debounceInterval;
   final bool _watchDependencies;
-  final Set<String>? _excludedPaths;
-  bool _isStopping = false;
-  Future<void> _pendingAutomaticReload = Future<void>.value();
+  final Set<String> _packagePathsToWatch;
+  final Set<String>? _projectPathsToExclude;
   final _watchedStreams = <StreamSubscription<List<WatchEvent>>>{};
   final vms.VmService _vmService;
 
@@ -150,7 +158,8 @@ For hot code reloading to function properly, Dart needs to be run from the root 
    */
   HotReloader._(
     this._watchDependencies,
-    this._excludedPaths,
+    this._packagePathsToWatch,
+    this._projectPathsToExclude,
     this._debounceInterval,
     this._vmService,
     this._onBeforeReload,
@@ -172,17 +181,21 @@ For hot code reloading to function properly, Dart needs to be run from the root 
       return;
     }
     final projectUri = Package.projectUri ?? packageUri;
-    final excludedPaths = (_excludedPaths ?? const {})
+    final projectPathsToExclude = (_projectPathsToExclude ?? const {})
         .map((e) => e.trim())
         .where((e) => e.isNotEmpty)
         .map(p.normalize)
-        .map(projectUri.resolve)
+        .map(Uri.directory)
+        .map(projectUri.resolveUri)
         .map((e) => e.toFilePath())
         .toSet();
-    final watchList = ['bin', 'lib', 'test']
-        .map(packageUri.resolve)
+    final watchList = _packagePathsToWatch
+        .map(Uri.directory)
+        .map(packageUri.resolveUri)
         .map((e) => e.toFilePath())
-        .whereIf(excludedPaths.isNotEmpty, (e) => !excludedPaths.contains(e))
+        .whereIf(projectPathsToExclude.isNotEmpty,
+          (e) => !projectPathsToExclude.contains(e),
+        )
         .toList();
 
     final configUri = Package.configUri;
@@ -201,8 +214,10 @@ For hot code reloading to function properly, Dart needs to be run from the root 
       } else {
         dependencies
             .where((e) => !e.isPubCached)
-            .whereIf(excludedPaths.isNotEmpty, (e) => !excludedPaths.contains(e.uri.toFilePath()))
             .map((e) => e.uri.toFilePath())
+            .whereIf(projectPathsToExclude.isNotEmpty,
+              (e) => !projectPathsToExclude.contains(e),
+            )
             .forEach(watchList.add);
       }
     }


### PR DESCRIPTION
*Issue #28*

*Description of changes:*
This allows us to modify the standard set of watching package folders, thereby providing functionality for projects with non-standard folders, such as Dart Frog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
