### PR TITLE
fix: Revert watching entire package directory. (#28)

### DIFF
--- a/lib/hotreloader.dart
+++ b/lib/hotreloader.dart
@@ -176,10 +176,11 @@ For hot code reloading to function properly, Dart needs to be run from the root 
         .map((e) => e.trim())
         .where((e) => e.isNotEmpty)
         .map(p.normalize)
-        .map(projectUri.resolve)
+        .map(Uri.directory)
+        .map(projectUri.resolveUri)
         .map((e) => e.toFilePath())
         .toSet();
-    final watchList = ['bin', 'lib', 'test']
+    final watchList = ['./', 'bin/', 'lib/', 'test/']
         .map(packageUri.resolve)
         .map((e) => e.toFilePath())
         .whereIf(excludedPaths.isNotEmpty, (e) => !excludedPaths.contains(e))


### PR DESCRIPTION
*Issue #28*

*Description of changes:*
Brings back watching the entire package's directory. This is a temporary solution to be released under 4.4.1 to eliminate breaking changes for non-standard projects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
